### PR TITLE
Chef fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ This resource manages pacemaker-resource group, supporting the following actions
 
 ### Examples
 ``` ruby
-pacemaker_clone 'mygroup' do
+pacemaker_group 'mygroup' do
   resources ['lbservice', 'vip']
   meta {}
   action :create

--- a/libraries/clihelper.rb
+++ b/libraries/clihelper.rb
@@ -36,7 +36,7 @@ module Clihelper
   def format_array(array_list)
     array_str = ''
     array_list.each do |value|
-      array_str << "#{value.shellescape} "
+      array_str << "#{value} "
     end
     array_str.strip
   end
@@ -54,7 +54,7 @@ module Clihelper
   def format_param_hash(param_hash)
     param_str = ''
     param_hash.each do |key, value|
-      param_str << "#{key.shellescape}=#{value.shellescape} "
+      param_str << "#{key}=#{value} "
     end
     param_str.strip
   end


### PR DESCRIPTION
Fixed an issue with the readme, and the libraries/clihelper that cause issues during chef runs ala:

    NoMethodError
    -------------
    undefined method `shellescape' for "ip":String
    
    Cookbook Trace:
    ---------------
    /var/chef/cache/cookbooks/pacemaker/libraries/clihelper.rb:57:in `block in format_param_hash'
    /var/chef/cache/cookbooks/pacemaker/libraries/clihelper.rb:56:in `each'
    /var/chef/cache/cookbooks/pacemaker/libraries/clihelper.rb:56:in `format_param_hash'
    /var/chef/cache/cookbooks/pacemaker/providers/primitive.rb:45:in `block (2 levels) in class_from_file'
    /var/chef/cache/cookbooks/pacemaker/providers/primitive.rb:43:in `block in class_from_file'
