### PR TITLE
Fix shellescape

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -18,6 +18,7 @@ suites:
       - recipe[yum]
       - recipe[pacemaker::node_prepare]
       - recipe[pacemaker::cluster_create]
+      - recipe[test::pacemaker_primitive]
     attributes:
       pacemaker:
         corosync:

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ This resource manages pacemaker-resource group, supporting the following actions
 
 ### Examples
 ``` ruby
-pacemaker_clone 'mygroup' do
+pacemaker_group 'mygroup' do
   resources ['lbservice', 'vip']
   meta {}
   action :create

--- a/libraries/clihelper.rb
+++ b/libraries/clihelper.rb
@@ -19,6 +19,8 @@
 # limitations under the License.
 #
 
+require 'shellwords'
+
 #
 # CLI Helper methods
 #

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,6 +5,8 @@ license          'Apache 2.0'
 description      'Installs/Configures pacemaker'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '1.0.0'
+source_url       'https://github.com/target/pacemaker-cookbook'
+issues_url       'https://github.com/target/pacemaker-cookbook/issues'
 
 depends 'hostsfile'
 depends 'chef-vault'

--- a/providers/orderset.rb
+++ b/providers/orderset.rb
@@ -28,7 +28,7 @@ def whyrun_supported?
 end
 
 action :create do
-  fail "No 'set' specificed to set for pacemaker_orderset[#{new_resource.name}]" if new_resource.set.nil?
+  raise "No 'set' specificed to set for pacemaker_orderset[#{new_resource.name}]" if new_resource.set.nil?
 
   execute "create pacemaker constraint orderset '#{new_resource.name}'" do
     new_resource.setoptions['id'] = new_resource.name

--- a/providers/primitive.rb
+++ b/providers/primitive.rb
@@ -28,7 +28,7 @@ def whyrun_supported?
 end
 
 action :create do
-  fail "No value specificed to set for pacemaker_primitive[#{new_resource.name}]" if new_resource.agent.nil?
+  raise "No value specificed to set for pacemaker_primitive[#{new_resource.name}]" if new_resource.agent.nil?
 
   addn_cmd = ''
 

--- a/providers/property.rb
+++ b/providers/property.rb
@@ -26,7 +26,7 @@ def whyrun_supported?
 end
 
 action :set do
-  fail "No value specificed to set for pacemaker_property[#{new_resource.name}]" if new_resource.value.nil?
+  raise "No value specificed to set for pacemaker_property[#{new_resource.name}]" if new_resource.value.nil?
 
   execute "set pacemaker property '#{new_resource.name}'" do
     command "pcs property set #{new_resource.name}=#{new_resource.value}"

--- a/providers/stonith.rb
+++ b/providers/stonith.rb
@@ -28,7 +28,7 @@ def whyrun_supported?
 end
 
 action :create do
-  fail "No agent specificed to set for pacemaker_stonith[#{new_resource.name}]" if new_resource.agent.nil?
+  raise "No agent specificed to set for pacemaker_stonith[#{new_resource.name}]" if new_resource.agent.nil?
 
   execute "create pacemaker stonith '#{new_resource.name}'" do
     command "pcs stonith create #{new_resource.name} #{new_resource.agent} #{format_param_hash(new_resource.params)} " \


### PR DESCRIPTION
Address #5 by including `shellwords` library.

Also addresses some rubocop and foodcritic warnings.