### PR TITLE
Added the no_vault option

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,6 +1,7 @@
 #==============================
 # PCS command configuration
 #==============================
+default['pacemaker']['no_vault'] = false
 default['pacemaker']['pcs']['vault'] = 'vault_pacemaker'
 default['pacemaker']['pcs']['vault_item'] = 'secrets'
 

--- a/providers/clone.rb
+++ b/providers/clone.rb
@@ -29,8 +29,10 @@ end
 
 action :create do
   execute "clone pacemaker resource '#{new_resource.name}'" do
-    command "pcs resource clone #{new_resource.name} #{format_array(new_resource.resources)}"
-    not_if "pcs resource show #{new_resource.name}"
+    command "pcs resource clone #{new_resource.name} " \
+            "#{format_param_hash(new_resource.params)}"
+    only_if "pcs resource show #{new_resource.name}"
+    not_if "pcs resource show #{new_resource.name}-clone"
   end
 end
 

--- a/providers/clone.rb
+++ b/providers/clone.rb
@@ -1,0 +1,42 @@
+# Author:: Petr Belyaev
+# Cookbook Name:: pacemaker
+# Resource:: clone
+#
+# Copyright 2016, Target Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+include ::Clihelper
+
+use_inline_resources
+
+# This resource supports the `--whyrun` flag,
+# Code that changes things is wrapped with `converge_by`
+def whyrun_supported?
+  true
+end
+
+action :create do
+  execute "clone pacemaker resource '#{new_resource.name}'" do
+    command "pcs resource clone #{new_resource.name} #{format_array(new_resource.resources)}"
+    not_if "pcs resource show #{new_resource.name}"
+  end
+end
+
+action :delete do
+  execute "delete pacemaker clone '#{new_resource.name}'" do
+    command "pcs resource unclone #{new_resource.name} --wait"
+    only_if "pcs resource show #{new_resource.name}"
+  end
+end

--- a/providers/primitive.rb
+++ b/providers/primitive.rb
@@ -39,6 +39,8 @@ action :create do
   end
 
   addn_cmd << ' --disabled' if new_resource.disabled
+  
+  addn_cmd << ' --force' if new_resource.force
 
   execute "create pacemaker primitive '#{new_resource.name}'" do
     exists = system "pcs resource show #{new_resource.name} &> /dev/null"

--- a/providers/primitive.rb
+++ b/providers/primitive.rb
@@ -33,9 +33,9 @@ action :create do
   addn_cmd = ''
 
   if new_resource.ms
-    addn_cmd = " --master #{new_resource.master_params}"
+    addn_cmd = " --master #{format_param_hash(new_resource.master_params)}"
   elsif new_resource.clone
-    addn_cmd = " --clone #{new_resource.clone_params}"
+    addn_cmd = " --clone #{format_param_hash(new_resource.clone_params)}"
   end
 
   addn_cmd << ' --disabled' if new_resource.disabled

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,0 +1,1 @@
+package 'pacemaker'

--- a/recipes/node_prepare.rb
+++ b/recipes/node_prepare.rb
@@ -17,9 +17,12 @@
 # limitations under the License.
 #
 
-include_recipe 'chef-vault::default'
-
-creds = chef_vault_item(node['pacemaker']['pcs']['vault'], node['pacemaker']['pcs']['vault_item'])
+if node['pacemaker']['no_vault']
+  creds = node['pacemaker']['pcs']['vault_item']
+else
+  include_recipe 'chef-vault::default'
+  creds = chef_vault_item(node['pacemaker']['pcs']['vault'], node['pacemaker']['pcs']['vault_item'])
+end
 
 package 'pcs'
 package 'fence-agents-all'
@@ -55,6 +58,11 @@ user 'hacluster' do
 end
 
 # Start service that syncronizes the cluster configs
+service 'pacemaker' do
+  supports restart: true, reload: true
+  action [:enable, :start]
+end
+
 service 'pcsd' do
   supports restart: true, reload: true, status: true
   action [:enable, :start]

--- a/resources/clone.rb
+++ b/resources/clone.rb
@@ -21,5 +21,5 @@ actions :create, :delete
 default_action :create
 
 attribute :name,       kind_of: String, name_attribute: true
-attribute :resources,  kind_of: Array,  required: true
+attribute :params,     kind_of: Hash,   default: {}
 attribute :meta,       kind_of: Hash,   default: {}

--- a/resources/clone.rb
+++ b/resources/clone.rb
@@ -1,0 +1,25 @@
+# Author:: Petr Belyaev
+# Cookbook Name:: pacemaker
+# Resource:: clone
+#
+# Copyright 2016, Target Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+actions :create, :delete
+default_action :create
+
+attribute :name,       kind_of: String, name_attribute: true
+attribute :resources,  kind_of: Array,  required: true
+attribute :meta,       kind_of: Hash,   default: {}

--- a/resources/primitive.rb
+++ b/resources/primitive.rb
@@ -28,3 +28,5 @@ attribute :meta,   kind_of: Hash,    default: {}
 attribute :ms,     kind_of: [TrueClass, FalseClass], default: false
 attribute :clone,  kind_of: [TrueClass, FalseClass], default: false
 attribute :disabled, kind_of: [TrueClass, FalseClass], default: false
+attribute :clone_params, kind_of: String
+attribute :master_params, kind_of: String

--- a/resources/primitive.rb
+++ b/resources/primitive.rb
@@ -30,3 +30,4 @@ attribute :clone,  kind_of: [TrueClass, FalseClass], default: false
 attribute :disabled, kind_of: [TrueClass, FalseClass], default: false
 attribute :clone_params, kind_of: Hash
 attribute :master_params, kind_of: Hash
+attribute :force, kind_of: [TrueClass, FalseClass], default: false

--- a/resources/primitive.rb
+++ b/resources/primitive.rb
@@ -28,5 +28,5 @@ attribute :meta,   kind_of: Hash,    default: {}
 attribute :ms,     kind_of: [TrueClass, FalseClass], default: false
 attribute :clone,  kind_of: [TrueClass, FalseClass], default: false
 attribute :disabled, kind_of: [TrueClass, FalseClass], default: false
-attribute :clone_params, kind_of: String
-attribute :master_params, kind_of: String
+attribute :clone_params, kind_of: Hash
+attribute :master_params, kind_of: Hash


### PR DESCRIPTION
Added the no_vault option that will just take the pre-defined password provided in the `node['pacemaker']['pcs']['vault_item']` since vault is not always available (e.g. for chef-solo).
Also added a package install directive to the default recipe since sometimes it's needed to just install the pacemaker without pcs.
